### PR TITLE
Version 0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+notes
+*.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM eclipse-temurin:21.0.1_12-jdk
+COPY ./target/nixie*.jar nixie.jar
+ENTRYPOINT ["java", "-jar", "nixie.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.5'
+
+services:
+  db:
+    image: postgres:15.4-alpine
+    container_name: db
+    restart: unless-stopped
+    env_file: variables.env
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  nixie:
+    image: nixie
+    build:
+      context: .
+    container_name: nixie
+    restart: unless-stopped
+    depends_on:
+      - db
+    env_file: variables.env
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/postgres
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
+      SPRING_JPA_HIBERNATE_DDL_AUTO: update
+      DISCORD_TOKEN: ${DISCORD_TOKEN}
+
+volumes:
+  postgres-data:

--- a/pom.xml
+++ b/pom.xml
@@ -2,15 +2,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.2.1</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
+
     <groupId>io.github.nightcalls</groupId>
     <artifactId>nixie</artifactId>
-    <version>0.2</version>
+    <version>0.3</version>
     <name>Nixie</name>
     <description>Discord bot for collecting activity statistics</description>
 
@@ -63,6 +65,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-datetime-jvm</artifactId>
+            <version>0.5.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/kotlin/io/github/nightcalls/nixie/listeners/SlashCommandEventListener.kt
+++ b/src/main/kotlin/io/github/nightcalls/nixie/listeners/SlashCommandEventListener.kt
@@ -4,6 +4,10 @@ import io.github.nightcalls.nixie.service.SlashCommandService
 import io.github.nightcalls.nixie.service.count.MessageCountService
 import io.github.nightcalls.nixie.service.count.VoiceTimeCountService
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.datetime.Clock
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.Instant
+import kotlinx.datetime.minus
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
@@ -16,6 +20,7 @@ class SlashCommandEventListener(
     private val messageCountService: MessageCountService,
     private val voiceTimeCountService: VoiceTimeCountService
 ) : ListenerAdapter() {
+    private var lastCommandTime: Instant = Clock.System.now().minus(10, DateTimeUnit.SECOND)
 
     override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
         if (event.guild != guild) {
@@ -25,8 +30,19 @@ class SlashCommandEventListener(
         logger.info { "Получен ${event.javaClass.simpleName}: ${event.name}" }
         when (event.name) {
             "nixie" -> slashCommandService.showInfo(event)
-            "stats-messages" -> messageCountService.showStats(event)
-            "stats-voices" -> voiceTimeCountService.showStats(event)
+            "stats-messages" -> checkCoolDown(event) { messageCountService.showStats(event) }
+            "stats-voices" -> checkCoolDown(event) { voiceTimeCountService.showStats(event) }
         }
+    }
+
+    private fun checkCoolDown(
+        event: SlashCommandInteractionEvent,
+        function: (event: SlashCommandInteractionEvent) -> Unit
+    ) {
+        if ((Clock.System.now() - lastCommandTime).inWholeSeconds < 10) {
+            return slashCommandService.coolDownReply(event)
+        }
+        lastCommandTime = Clock.System.now()
+        return function(event)
     }
 }

--- a/src/main/kotlin/io/github/nightcalls/nixie/listeners/VoiceEventListener.kt
+++ b/src/main/kotlin/io/github/nightcalls/nixie/listeners/VoiceEventListener.kt
@@ -21,7 +21,7 @@ open class VoiceEventListener(
             return
         }
 
-        val eventTime = OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.of("+03:00"))
+        val eventTime = OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.of("+03:00")).toLocalDateTime()
         val eventDto = VoiceEventDto(event, eventTime)
         logger.info { "Получен ${event.javaClass.simpleName}: $eventDto" }
         service.incrementOrCreateCount(eventDto)

--- a/src/main/kotlin/io/github/nightcalls/nixie/listeners/dto/VoiceEventDto.kt
+++ b/src/main/kotlin/io/github/nightcalls/nixie/listeners/dto/VoiceEventDto.kt
@@ -2,20 +2,28 @@ package io.github.nightcalls.nixie.listeners.dto
 
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent
 import java.time.LocalDate
-import java.time.OffsetDateTime
+import java.time.LocalDateTime
 
 data class VoiceEventDto(
     val guildId: Long,
     val userId: Long,
     val date: LocalDate,
-    val time: Long,
+    val time: LocalDateTime,
     val isLeaving: Boolean
 ) {
-    constructor(event: GuildVoiceUpdateEvent, time: OffsetDateTime) : this(
+    constructor(event: GuildVoiceUpdateEvent, time: LocalDateTime) : this(
         event.guild.idLong,
         event.entity.user.idLong,
         time.toLocalDate(),
-        time.toEpochSecond(),
+        time,
         event.channelJoined == null
+    )
+
+    constructor(eventDto: VoiceEventDto, date: LocalDate) : this(
+        eventDto.guildId,
+        eventDto.userId,
+        date,
+        eventDto.time,
+        eventDto.isLeaving
     )
 }

--- a/src/main/kotlin/io/github/nightcalls/nixie/repository/record/UserInVoiceRecord.kt
+++ b/src/main/kotlin/io/github/nightcalls/nixie/repository/record/UserInVoiceRecord.kt
@@ -2,6 +2,7 @@ package io.github.nightcalls.nixie.repository.record
 
 import io.github.nightcalls.nixie.listeners.dto.VoiceEventDto
 import jakarta.persistence.*
+import java.time.LocalDateTime
 
 @Entity
 @Table(
@@ -29,7 +30,7 @@ data class UserInVoiceRecord(
      * Время входа в голосовой канал
      */
     @Column(nullable = false)
-    val entryTime: Long
+    val entryTime: LocalDateTime
 ) {
     constructor(eventDto: VoiceEventDto) : this(
         guildId = eventDto.guildId,

--- a/src/main/kotlin/io/github/nightcalls/nixie/service/SlashCommandService.kt
+++ b/src/main/kotlin/io/github/nightcalls/nixie/service/SlashCommandService.kt
@@ -1,7 +1,11 @@
 package io.github.nightcalls.nixie.service
 
+import io.github.nightcalls.nixie.utils.getCommonEmbedBuilder
+import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
 import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger {}
 
 @Service
 class SlashCommandService {
@@ -9,12 +13,32 @@ class SlashCommandService {
      * Вывод инструкции по использованию бота
      */
     fun showInfo(event: SlashCommandInteractionEvent) {
-        val info = StringBuilder()
-        info
-            .append("/stats-messages — статистика по сообщениям всех пользователей за последние 30 дней")
-            .append("\n/stats-voices — статистика по времени в войсе всех пользователей за последние 30 дней")
-            .append("\n\nОбратную связь можно оставить по адресу nixiethebat@gmail.com")
+        val embedBuilder = getCommonEmbedBuilder()
+        embedBuilder.setTitle("Инфо")
+        embedBuilder.addField(
+            "/stats-messages", "Статистика по количеству отправленных сообщений", false
+        )
+        embedBuilder.addField(
+            "/stats-voices", "Статистика по проведенному в голосовых каналах времени", false
+        )
+        embedBuilder.addField(
+            "nixiethebat@gmail.com", "Адрес для обратной связи", false
+        )
 
-        event.reply(info.toString()).queue()
+        event.member?.asMention?.let { event.reply(it).addEmbeds(embedBuilder.build()).queue() }
+        logger.info { "Отправлена инструкция по использованию бота на сервер ${event.guild?.name}" }
+    }
+
+    /**
+     * Вывод предупреждения о задержке
+     */
+    fun coolDownReply(event: SlashCommandInteractionEvent) {
+        val embedBuilder = getCommonEmbedBuilder()
+        embedBuilder.addField(
+            "Предупреждение", "Команды вывода статистики можно вызывать не чаще, чем раз в 10 секунд", false
+        )
+
+        event.member?.asMention?.let { event.reply(it).addEmbeds(embedBuilder.build()).setEphemeral(true).queue() }
+        logger.info { "Отправлено предупреждение о задержке на сервер ${event.guild?.name}" }
     }
 }

--- a/src/main/kotlin/io/github/nightcalls/nixie/service/count/CommonCountService.kt
+++ b/src/main/kotlin/io/github/nightcalls/nixie/service/count/CommonCountService.kt
@@ -3,7 +3,10 @@ package io.github.nightcalls.nixie.service.count
 import io.github.nightcalls.nixie.service.UserIdService
 import io.github.nightcalls.nixie.service.count.view.IdCountPair
 import io.github.nightcalls.nixie.service.count.view.NameValuePair
+import io.github.nightcalls.nixie.utils.getCommonEmbedBuilder
 import io.github.oshai.kotlinlogging.KotlinLogging
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.interactions.InteractionHook
 import org.apache.commons.lang3.StringUtils
 import org.springframework.stereotype.Service
 
@@ -28,7 +31,15 @@ class CommonCountService(
         )
     }
 
-    fun createTableOutput(viewsList: List<NameValuePair>): String {
+    /**
+     * Формирование вывода статистики и отправка его частями в случае превышения установленной в Discord длины в 2000 символов
+     */
+    fun createTableOutputsAndMultipleReplies(event: SlashCommandInteractionEvent, viewsList: List<NameValuePair>) {
+        val embedBuilder = getCommonEmbedBuilder()
+        embedBuilder.setDescription("Сформирована статистика")
+        event.member?.asMention?.let { event.reply(it).addEmbeds(embedBuilder.build()).queue() }
+        val hook = event.hook
+
         val firstColumnWidth = viewsList.size.toString().length + 3
         val secondColumnWidth = viewsList.maxBy { it.name.length }.name.length + 2
         logger.debug { "Рассчитаны ширины первого ($firstColumnWidth) и второго ($secondColumnWidth) столбцов" }
@@ -39,8 +50,20 @@ class CommonCountService(
             val firstColumn = StringUtils.rightPad("${i++}. -", firstColumnWidth, "-")
             val secondColumn = StringUtils.rightPad("${it.name} -", secondColumnWidth, "-")
             result.append("$firstColumn $secondColumn ${it.value}\n")
+
+            if (result.length > 1950) {
+                sendResultWithHook(hook, result)
+                result.setLength(0)
+                result.append("```")
+            }
         }
+        sendResultWithHook(hook, result)
+    }
+
+    private fun sendResultWithHook(hook: InteractionHook, result: java.lang.StringBuilder) {
         result.append("```")
-        return result.toString()
+        val embedBuilder = getCommonEmbedBuilder()
+        embedBuilder.setDescription(result)
+        hook.sendMessageEmbeds(embedBuilder.build()).queue()
     }
 }

--- a/src/main/kotlin/io/github/nightcalls/nixie/service/count/MessageCountService.kt
+++ b/src/main/kotlin/io/github/nightcalls/nixie/service/count/MessageCountService.kt
@@ -42,6 +42,7 @@ class MessageCountService(
             result
         }.map { createCountView(it) }
 
-        event.reply(createTableOutput(messageViewsList)).queue()
+        createTableOutputsAndMultipleReplies(event, messageViewsList)
+        logger.info { "Отправлена статистика сообщений на сервер ${event.guild?.name}" }
     }
 }

--- a/src/main/kotlin/io/github/nightcalls/nixie/utils/EmbedUtils.kt
+++ b/src/main/kotlin/io/github/nightcalls/nixie/utils/EmbedUtils.kt
@@ -1,0 +1,10 @@
+package io.github.nightcalls.nixie.utils
+
+import net.dv8tion.jda.api.EmbedBuilder
+import java.awt.Color
+
+fun getCommonEmbedBuilder(): EmbedBuilder {
+    val embedBuilder = EmbedBuilder()
+    embedBuilder.setColor(Color(90, 84, 143))
+    return embedBuilder
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,0 @@
-discord.token=${DISCORD_TOKEN}
-spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.url=${DATABASE_URL}
-spring.datasource.username=${DATABASE_USER}
-spring.datasource.password=${DATABASE_PASSWORD}
-spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO}
+discord:
+  token: ${DISCORD_TOKEN}


### PR DESCRIPTION
Моменты времени теперь записываются не в секундах, а в LocalDateTime.
Сделана задержка на вызовы методов формирования статистики в рамках каждого конкретного сервера.
Результаты слэш-команд теперь выводятся с использованием embed'ов.
Вывод статистики поделен на сообщения длиной не более 2000 символов.
В случаях сессий в войсах, затрагивающих несколько дней, учтённое время записывается в соответствующие дни.
Файл application.properties переведен в формат .yml.
Приложение и его база данных упакованы в Docker-контейнеры.