### PR TITLE
Version 0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM eclipse-temurin:21.0.1_12-jdk
+FROM eclipse-temurin:17.0.10_7-jdk
 COPY ./target/nixie*.jar nixie.jar
 ENTRYPOINT ["java", "-jar", "nixie.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.5'
+version: '3.8'
 
 services:
   db:
@@ -13,7 +13,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "127.0.0.1:15432:5432"
 
   nixie:
     image: nixie
@@ -30,6 +30,7 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
       SPRING_JPA_HIBERNATE_DDL_AUTO: update
       DISCORD_TOKEN: ${DISCORD_TOKEN}
+      LOGGING_LEVEL: info
 
 volumes:
   postgres-data:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/src/main/kotlin/io/github/nightcalls/nixie/config/JdaConfiguration.kt
+++ b/src/main/kotlin/io/github/nightcalls/nixie/config/JdaConfiguration.kt
@@ -5,6 +5,8 @@ import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.JDABuilder
 import net.dv8tion.jda.api.entities.Activity
 import net.dv8tion.jda.api.requests.GatewayIntent
+import net.dv8tion.jda.api.utils.ChunkingFilter
+import net.dv8tion.jda.api.utils.MemberCachePolicy
 import net.dv8tion.jda.api.utils.cache.CacheFlag
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -37,7 +39,8 @@ class JdaConfiguration(
         return JDABuilder.create(
             token,
             GatewayIntent.GUILD_MESSAGES, // для сбора статистики сообщений
-            GatewayIntent.GUILD_VOICE_STATES // для сбора статистики входов и выходов из войсов
+            GatewayIntent.GUILD_VOICE_STATES, // для сбора статистики входов и выходов из войсов
+            GatewayIntent.GUILD_MEMBERS // для удаления участников из кэша, после того как они покинут гильдию
         )
             .disableCache(
                 CacheFlag.ACTIVITY,
@@ -47,6 +50,8 @@ class JdaConfiguration(
                 CacheFlag.ONLINE_STATUS,
                 CacheFlag.SCHEDULED_EVENTS
             )
+            .setMemberCachePolicy(MemberCachePolicy.ALL)
+            .setChunkingFilter(ChunkingFilter.ALL)
             .setActivity(Activity.listening("/nixie"))
     }
 }

--- a/src/main/kotlin/io/github/nightcalls/nixie/listeners/VoiceEventListener.kt
+++ b/src/main/kotlin/io/github/nightcalls/nixie/listeners/VoiceEventListener.kt
@@ -2,12 +2,12 @@ package io.github.nightcalls.nixie.listeners
 
 import io.github.nightcalls.nixie.listeners.dto.VoiceEventDto
 import io.github.nightcalls.nixie.service.count.VoiceTimeCountService
+import io.github.nightcalls.nixie.utils.toCommonLocalDateTime
 import io.github.oshai.kotlinlogging.KotlinLogging
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import java.time.OffsetDateTime
-import java.time.ZoneOffset
 
 private val logger = KotlinLogging.logger {}
 
@@ -21,7 +21,7 @@ open class VoiceEventListener(
             return
         }
 
-        val eventTime = OffsetDateTime.now().withOffsetSameInstant(ZoneOffset.of("+03:00")).toLocalDateTime()
+        val eventTime = OffsetDateTime.now().toCommonLocalDateTime()
         val eventDto = VoiceEventDto(event, eventTime)
         logger.info { "Получен ${event.javaClass.simpleName}: $eventDto" }
         service.incrementOrCreateCount(eventDto)

--- a/src/main/kotlin/io/github/nightcalls/nixie/listeners/dto/MessageEventDto.kt
+++ b/src/main/kotlin/io/github/nightcalls/nixie/listeners/dto/MessageEventDto.kt
@@ -1,8 +1,8 @@
 package io.github.nightcalls.nixie.listeners.dto
 
+import io.github.nightcalls.nixie.utils.toCommonLocalDateTime
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import java.time.LocalDate
-import java.time.ZoneOffset
 
 data class MessageEventDto(
     val guildId: Long,
@@ -12,6 +12,6 @@ data class MessageEventDto(
     constructor(event: MessageReceivedEvent) : this(
         event.guild.idLong,
         event.author.idLong,
-        event.message.timeCreated.withOffsetSameInstant(ZoneOffset.of("+03:00")).toLocalDate(),
+        event.message.timeCreated.toCommonLocalDateTime().toLocalDate(),
     )
 }

--- a/src/main/kotlin/io/github/nightcalls/nixie/service/SlashCommandService.kt
+++ b/src/main/kotlin/io/github/nightcalls/nixie/service/SlashCommandService.kt
@@ -25,7 +25,7 @@ class SlashCommandService {
             "nixiethebat@gmail.com", "Адрес для обратной связи", false
         )
 
-        event.member?.asMention?.let { event.reply(it).addEmbeds(embedBuilder.build()).queue() }
+        event.member?.asMention?.let { event.reply(it).addEmbeds(embedBuilder.build()).setEphemeral(true).queue() }
         logger.info { "Отправлена инструкция по использованию бота на сервер ${event.guild?.name}" }
     }
 

--- a/src/main/kotlin/io/github/nightcalls/nixie/service/count/MessageCountService.kt
+++ b/src/main/kotlin/io/github/nightcalls/nixie/service/count/MessageCountService.kt
@@ -36,12 +36,15 @@ class MessageCountService(
      */
     @Transactional
     fun showStats(event: SlashCommandInteractionEvent) {
+        event.deferReply(true).queue()
+
         val messageViewsList = event.guild!!.let {
             val result = repository.sumCountsForGuildIdGroupByUserId(it.idLong)
             logger.debug { "При сборе статистики сообщений было сформировано ${result.size} записей" }
             result
         }.map { createCountView(it) }
 
+        sendTitleEmbed(event, "Сформирована статистика по количеству отправленных сообщений")
         createTableOutputsAndMultipleReplies(event, messageViewsList)
         logger.info { "Отправлена статистика сообщений на сервер ${event.guild?.name}" }
     }

--- a/src/main/kotlin/io/github/nightcalls/nixie/service/count/VoiceTimeCountService.kt
+++ b/src/main/kotlin/io/github/nightcalls/nixie/service/count/VoiceTimeCountService.kt
@@ -39,12 +39,15 @@ class VoiceTimeCountService(
      */
     @Transactional
     fun showStats(event: SlashCommandInteractionEvent) {
+        event.deferReply(true).queue()
+
         val messageViewsList = event.guild!!.let {
             val result = voiceTimeRepository.sumTimeForGuildIdGroupByUserId(it.idLong)
             logger.debug { "При сборе статистики времени в войсе было сформировано ${result.size} записей" }
             result
         }.map { createCountViewWithTimeFormat(it) }
 
+        sendTitleEmbed(event, "Сформирована статистика по проведенному в голосовых каналах времени")
         createTableOutputsAndMultipleReplies(event, messageViewsList)
         logger.info { "Отправлена статистика времени в войсе на сервер ${event.guild?.name}" }
     }

--- a/src/main/kotlin/io/github/nightcalls/nixie/utils/TimeUtils.kt
+++ b/src/main/kotlin/io/github/nightcalls/nixie/utils/TimeUtils.kt
@@ -1,0 +1,9 @@
+package io.github.nightcalls.nixie.utils
+
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+fun OffsetDateTime.toCommonLocalDateTime(): LocalDateTime {
+    return this.withOffsetSameInstant(ZoneOffset.of("+03:00")).toLocalDateTime()
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,6 @@ spring:
       ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO}
 discord:
   token: ${DISCORD_TOKEN}
+logging:
+  level:
+    root: ${LOGGING_LEVEL}


### PR DESCRIPTION
Сделано удержание ивента более чем на 3 секунды, чтобы статистика успевала сформироваться.
Организовано кэширование пользователей с серверов, на которых бот активен.
Статистика теперь выводится как файл с предварительным просмотром, embed'ы и проверка на превышение длины убраны.
В сформированную статистику добавлены данные о сервере, инициаторе и периоде собранных данных.
Доработан вывод в случае вызова команд при отсутствии собранных данных.
Уточнено сообщение "сформирована статистика", также теперь оно отправляется уже после обработки статистики.
Информационное сообщение сделано эфемерным.
Использование значения часового пояса вынесено в TimeUtils.
В docker-compose добавлена переменная уровня логирования.
Задан адрес для подключения pgAdmin.
Версия JDK образа докера понижена до 17-й.